### PR TITLE
Added fallback check for group_id to check for group_name

### DIFF
--- a/src/Command/AbstractCreateFieldCommand.php
+++ b/src/Command/AbstractCreateFieldCommand.php
@@ -130,7 +130,18 @@ abstract class AbstractCreateFieldCommand extends Command implements Conditional
     {
         $instance = $this->getApplication()->newControllerInstance('\\eecli\\CodeIgniter\\Controller\\AdminContentController');
 
-        $groupId = $this->argument('group_id');
+        if(!is_numeric($groupId)) {
+            $query = $instance->db->select('group_id')
+                ->where('group_name', $groupId)
+                ->limit(1)
+                ->get('field_groups');
+
+            if ($query->num_rows() > 0) {
+                $groupId = $query->row('group_id');
+            }
+
+            $query->free_result();
+        }
 
         $name = $this->argument('short_name');
 


### PR DESCRIPTION
This allows you to call `eecli create:field:wygwam "Content" "content" blog` and add a field to the 'blog' group.